### PR TITLE
implementação de filtros adicionais para o endpoint de get papers

### DIFF
--- a/api/adapters/repository/paper.py
+++ b/api/adapters/repository/paper.py
@@ -1,3 +1,5 @@
+from typing import Optional, List
+
 from api.config.postgres import SessionLocal
 from api.models.dto.paper import PaperDTO, PaperToUpdateDTO
 from api.models.paper import Paper
@@ -65,6 +67,37 @@ class PaperAdapter(PaperRepository):
         )
 
         return [area[0] for area in areas]
+
+    def get_not_ignored_papers(self) -> List[Paper]:
+        return (
+            self._session.query(Paper)
+            .filter(Paper.is_ignored == False)
+            .order_by(Paper.title)
+            .all()
+        )
+
+    def filter_papers_by_criteria(
+            self,
+            title: Optional[str] = None,
+            author: Optional[str] = None,
+            pdf_id: Optional[str] = None,
+            area: Optional[str] = None,
+            event_id: Optional[int] = None,
+    ) -> List[Paper]:
+        query = self._session.query(Paper)
+
+        if title:
+            query = query.filter(Paper.title == title)
+        if author:
+            query = query.filter(Paper.authors.contains(author))
+        if pdf_id:
+            query = query.filter(Paper.pdf_id == pdf_id)
+        if area:
+            query = query.filter(Paper.area == area)
+        if event_id:
+            query = query.filter(Paper.event_id == event_id)
+
+        return query.order_by(Paper.title).all()
 
     def update_paper(self, pdf_id: int, paper: PaperToUpdateDTO) -> Paper:
         paper_data = self._session.query(Paper).filter(Paper.pdf_id == pdf_id).first()

--- a/api/controllers/paper.py
+++ b/api/controllers/paper.py
@@ -1,18 +1,16 @@
-from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+from typing import List, Optional
+from api.models.dto.paper import PaperSchema
+from api.models.paper import Paper
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status, HTTPException
 from api.adapters.repository.event import EventAdapter
 from api.adapters.repository.paper import PaperAdapter
-from api.services.paper import (
-    BatchPapersResponse,
-    PaperService,
-    PapersPaginatedResponse,
-)
+from api.services.paper import PaperService, BatchPapersResponse, PapersPaginatedResponse
 
 router = APIRouter()
 
-adapter = PaperAdapter()
+paper_adapter = PaperAdapter()
 event_adapter = EventAdapter()
-service = PaperService(adapter, event_adapter)
-
+paper_service = PaperService(paper_adapter, event_adapter)
 
 @router.patch(
     "/upload_csv/events/{event_id}",
@@ -20,17 +18,39 @@ service = PaperService(adapter, event_adapter)
     status_code=status.HTTP_207_MULTI_STATUS,
 )
 async def batch_update_papers(
-    event_id: int,
-    file: UploadFile = File(...),
-    paper_service: PaperService = Depends(lambda: service),
+        event_id: int,
+        file: UploadFile = File(...),
+        paper_service: PaperService = Depends(lambda: paper_service),
 ):
     return await paper_service.batch_update_papers(event_id, file)
 
-
 @router.get("", response_model=PapersPaginatedResponse, status_code=status.HTTP_200_OK)
 def get_papers(
-    page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=10, ge=1, le=100),
-    paper_service: PaperService = Depends(lambda: service),
+        page: int = Query(default=1, ge=1),
+        page_size: int = Query(default=10, ge=1, le=100),
+        paper_service: PaperService = Depends(lambda: paper_service),
 ):
     return paper_service.get_papers(page, page_size)
+
+@router.get("/not_ignored", response_model=List[PaperSchema], status_code=status.HTTP_200_OK)
+def get_not_ignored_papers(paper_service: PaperService = Depends(lambda: paper_service)):
+    not_ignored_papers = paper_service.get_not_ignored_papers()
+    if not not_ignored_papers:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No papers found")
+    return not_ignored_papers
+
+@router.get("/papersFilter", response_model=List[PaperSchema], status_code=status.HTTP_200_OK)
+def filter_papers_by_criteria(
+        title: Optional[str] = None,
+        author: Optional[str] = None,
+        pdf_id: Optional[str] = None,
+        area: Optional[str] = None,
+        event_id: Optional[int] = None,
+        paper_service: PaperService = Depends(lambda: paper_service),
+):
+    filtered_papers = paper_service.filter_papers_by_criteria(
+        title=title, author=author, pdf_id=pdf_id, area=area, event_id=event_id
+    )
+    if not filtered_papers:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No papers found")
+    return filtered_papers

--- a/api/models/dto/paper.py
+++ b/api/models/dto/paper.py
@@ -17,3 +17,13 @@ class PaperToUpdateDTO(BaseModel):
     title: str
     authors: str
     is_ignored: bool
+
+
+class PaperSchema(BaseModel):
+    pdf_id: str
+    area: Optional[str]
+    title: Optional[str]
+    authors: Optional[str]
+    is_ignored: Optional[bool]
+    total_pages: int
+    event_id: int

--- a/api/services/paper.py
+++ b/api/services/paper.py
@@ -1,7 +1,11 @@
 import csv
 from math import ceil
+from typing import Optional, List
+
 from fastapi import File, HTTPException, UploadFile, status
 from pydantic import BaseModel
+
+from api.models import Paper
 from api.models.dto.paper import PaperToUpdateDTO
 from api.models.responses.paper import PaperResponse
 from api.ports.event import EventRepository
@@ -103,4 +107,23 @@ class PaperService:
             total_papers=self._paper_repo.count_papers(),
             total_pages=ceil(self._paper_repo.count_papers() / page_size),
             current_page=page,
+        )
+
+    def get_not_ignored_papers(self) -> List[Paper]:
+        not_ignored_papers = self._paper_repo.get_not_ignored_papers()
+        if not not_ignored_papers:
+            raise HTTPException(status_code=404, detail=" No -not ignored papers- found")
+
+        return not_ignored_papers
+
+    def filter_papers_by_criteria(
+            self,
+            title: Optional[str] = None,
+            author: Optional[str] = None,
+            pdf_id: Optional[str] = None,
+            area: Optional[str] = None,
+            event_id: Optional[int] = None,
+    ) -> List[Paper]:
+        return self._paper_repo.filter_papers_by_criteria(
+            title=title, author=author, pdf_id=pdf_id, area=area, event_id=event_id
         )


### PR DESCRIPTION
Esta alteração implementa filtros adicionais para a busca de papers no novo endpoint /papersFilter, permitindo filtrar os papers por título, autor, ID do PDF, área e ID do evento. Além disso, também foi adicionado um endpoint relacionado ao filtro de papers com IS_IGNORED = FALSE no endpoint /not_ignored, garantindo que os papers com o campo is_ignored definido como False sejam retornados.

Selecione abaixo o item coerente com o tipo de implementação realizado.

- [  ] Correção de bug [bugfix] (alteração ininterrupta que corrige um problema)
- [x] Novo recurso [feature] (alteração ininterrupta que adiciona funcionalidade)
- [  ] Alteração significativa [hotfix] (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [  ] Esta alteração requer uma atualização da documentação [docs]
- [  ] Recursos de testes [test] (Implementação de recursos para validação/testes no código)
- [  ] Outro recurso não listado nas opções acima [other]

**Como isso foi testado?**

Essa implementação foi testada manualmente e incluiu os seguintes passos:

- [x]  Teste de filtros por título, autor, ID do PDF, área e ID do evento no endpoint /papersFilter.
- [x] Verificação dos resultados para garantir que apenas os papers correspondentes aos filtros especificados foram retornados.
- [x] Teste do filtro de papers não ignorados no endpoint /not_ignored para garantir que apenas os papers com is_ignored definido como False sejam retornados.
- [x] Verificação da resposta para garantir que os papers sejam retornados corretamente em caso de êxito e que uma mensagem apropriada seja retornada em caso de nenhum paper encontrado.

**Configuração de teste:**

-     Versão do framework/SDK: FastAPI v0.109.2
-     Browser/Ferramenta utilizada: Postman v8.6.2 e Swagger http://127.0.0.1:8000/docs
-    Caminho a ser testado: /papersFilter, /not_ignored
    
**Lista de controle:**
 

- [x]  Meu código segue as diretrizes de estilo deste projeto
- [x]  Realizei uma auto-revisão do meu código
- [ ] Comentei meu código, principalmente em áreas difíceis de entender
- [ ]  Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos avisos
- [ ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [ ] Testes de unidade novos e existentes passam localmente com minhas alterações
- [ ] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream
