### PR TITLE
Filtro evento

### DIFF
--- a/api/adapters/repository/event.py
+++ b/api/adapters/repository/event.py
@@ -66,7 +66,7 @@ class EventAdapter(EventRepository):
         return event
     
     def get_events_by_name(self, name: str) -> list[Event]:
-        return self._session.query(Event).filter(Event.name == name).all()
+        return self._session.query(Event).filter(Event.name.contains(name)).all()
     
     def get_event_by_initial_date(self, initial_date: str) -> list[Event]:
         return self._session.query(Event).filter(Event.initial_date == initial_date).all()

--- a/api/adapters/repository/event.py
+++ b/api/adapters/repository/event.py
@@ -67,3 +67,9 @@ class EventAdapter(EventRepository):
     
     def get_events_by_name(self, name: str) -> list[Event]:
         return self._session.query(Event).filter(Event.name == name).all()
+    
+    def get_event_by_initial_date(self, initial_date: str) -> list[Event]:
+        return self._session.query(Event).filter(Event.initial_date == initial_date).all()
+    
+    def get_event_by_final_date(self, final_date: str) -> list[Event]:
+        return self._session.query(Event).filter(Event.final_date == final_date).all()

--- a/api/adapters/repository/event.py
+++ b/api/adapters/repository/event.py
@@ -64,3 +64,6 @@ class EventAdapter(EventRepository):
         self._session.refresh(event)
 
         return event
+    
+    def get_events_by_name(self, name: str) -> list[Event]:
+        return self._session.query(Event).filter(Event.name == name).all()

--- a/api/controllers/event.py
+++ b/api/controllers/event.py
@@ -31,32 +31,7 @@ merged_papers_service = MergedPapersService(
 
 anal_service = AnalService(file_handler_service, event_adapter)
 
-# class EventFilter(Filter):
-#     name: Optional[str] = None
-#     name_ilike: Optional[str] = None
-#     name_like: Optional[str] = None
-#     initial_date: Optional[str] = None
-#     final_date: Optional[str] = None
-    
-#     search: Optional[str] = None
-    
-#     class Constants(Filter.Constants):
-#         model = EventResponse
-#         search_model_fields = ["name", "initial_date", "final_date"]
-        
-# app = FastAPI()
-
-# @router.get("/events-search", response_model=List[EventResponse], status_code=status.HTTP_200_OK)
-# async def get_events(
-#     event_filter: EventFilter = Depends(EventFilter),
-#     db: AsyncSession = Depends(lambda: app.state.db)
-# ) -> List[EventResponse]:
-#     query = select(EventResponse)
-#     query = event_filter.filter(query)
-#     result = await db.execute(query)
-#     return [EventResponse.from_dict(event) for event in result.scalars().all()]
-
-@router.get("/events", response_model=List[EventResponse], status_code=status.HTTP_200_OK)
+@router.get("/name", response_model=List[EventResponse], status_code=status.HTTP_200_OK)
 def get_events_by_name(
     name: str = Query(..., description="Event name"),
     event_service: EventService = Depends(lambda: service),
@@ -65,6 +40,28 @@ def get_events_by_name(
     if not events:
         raise HTTPException(status_code=404, detail="Event not found")
     return events
+
+@router.get("/dateinitial", response_model=List[EventResponse], status_code=status.HTTP_200_OK)
+def get_event_by_initial_date(
+    initial_date: str = Query(..., description="Event initial date"),
+    event_service: EventService = Depends(lambda: service),
+):
+    events = event_service.get_events_by_initial_date(initial_date)
+    if not events:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return events
+
+@router.get("/datefinal", response_model=List[EventResponse], status_code=status.HTTP_200_OK)
+def get_event_by_final_date(
+    final_date: str = Query(..., description="Event final date"),
+    event_service: EventService = Depends(lambda: service),
+):
+    events = event_service.get_events_by_final_date(final_date)
+    if not events:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return events
+
+
 
 
 

--- a/api/models/responses/event.py
+++ b/api/models/responses/event.py
@@ -38,3 +38,10 @@ class EventResponse(BaseModel):
                 else None
             ),
         )
+        
+    @classmethod
+    def from_dict(cls, event_dict: dict) -> "EventResponse":
+        return cls(**event_dict)
+
+    def to_dict(self) -> dict:
+        return self.dict()

--- a/api/services/event.py
+++ b/api/services/event.py
@@ -81,3 +81,19 @@ class EventService:
         ]
 
         return events_response
+
+    def get_events_by_initial_date(self, initial_date: str) -> list[EventResponse]:
+        events_data = self._event_repo.get_event_by_initial_date(initial_date)
+        events_response = [
+            EventResponse.from_event(event_data) for event_data in events_data
+        ]
+
+        return events_response
+    
+    def get_events_by_final_date(self, final_date: str) -> list[EventResponse]:
+        events_data = self._event_repo.get_event_by_final_date(final_date)
+        events_response = [
+            EventResponse.from_event(event_data) for event_data in events_data
+        ]
+
+        return events_response

--- a/api/services/event.py
+++ b/api/services/event.py
@@ -73,3 +73,11 @@ class EventService:
         return EventResponse.from_event(
             self._event_repo.update_anal_filename(event_id, anal_filename)
         )
+        
+    def get_events_by_name(self, name: str) -> list[EventResponse]:
+        events_data = self._event_repo.get_events_by_name(name)
+        events_response = [
+            EventResponse.from_event(event_data) for event_data in events_data
+        ]
+
+        return events_response

--- a/api/services/merged_papers.py
+++ b/api/services/merged_papers.py
@@ -153,6 +153,7 @@ class MergedPapersService:
                 filename,
             )
 
+    #TODO: Change this for update paper
     def _create_paper_from_pdf(
         self, temp_dir: str, filename: str, event_id: int
     ) -> None:
@@ -162,6 +163,7 @@ class MergedPapersService:
 
         if pdf_id.split()[0] not in self._papers_registered:
             self._paper_repo.create_paper(
+                # TODO: Change to PaperToUpdateDTO
                 PaperDTO(
                     pdf_id=pdf_id,
                     area=None,

--- a/api/services/paper.py
+++ b/api/services/paper.py
@@ -39,7 +39,7 @@ class PaperService:
         if not event.merged_papers_filename:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Merged paprs file not found",
+                detail="Merged papers file not found",
             )
 
         if self._paper_repo.count_papers_by_event_id(event_id) == 0:
@@ -63,13 +63,15 @@ class PaperService:
             self._update_paper_by_csv_row(row, batch_papers)
 
         return batch_papers
-
+    
+    #TODO: Change this to create paper
     def _update_paper_by_csv_row(
         self, row, batch_papers_response: list[BatchPapersResponse]
     ) -> None:
         try:
             self._paper_repo.update_paper(
                 row["id"],
+                #TODO: Change this to PaperDTO
                 PaperToUpdateDTO(
                     area=row["area"],
                     title=row["titulo"],


### PR DESCRIPTION
# Descrição

Foi adicionado novos filtros para o evento, podendo agora pesquisar por nome do evento ou data inicial, ou data final. 


## Tipo de mudança
Selecione abaixo o item coerente com o tipo de implementação realizado.

- [  ] Correção de bug [bugfix] (alteração ininterrupta que corrige um problema)
- [X] Novo recurso [feature] (alteração ininterrupta que adiciona funcionalidade)
- [  ] Alteração significativa [hotfix] (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [  ] Esta alteração requer uma atualização da documentação [docs]
- [  ] Recursos de testes [test] (Implementação de recursos para validação/testes no código)
- [  ] Outro recurso não listado nas opções acima [other]

# Como isso foi testado?

Testes manuais no (http://127.0.0.1:8000/docs) do projeto


- [X] Entrar no /docs e fui para filtro de "Get events by name", cliquei no botão do Try e escrevi nomes que estavam salvos como eventos e nomes que também não estavam.
- [X] Entrar no /docs e fui para filtro de "Get events by inital date", cliquei no botão do Try e escrevi datas que estavam salvas como eventos e datas que também não estavam.
- [X] Entrar no /docs e fui para filtro de "Get events by final date", cliquei no botão do Try e escrevi datas que estavam salvas como eventos e datas que também não estavam.

**Configuração de teste**:
* Versão do framework/SDK: FastAPI v0.109.2
* Browser/Ferramenta utilizada: http://127.0.0.1:8000/docs
* Caminho a ser testado: /events/name , /events/dateinitial e /events/datefinal

# Lista de controle:

- [X] Meu código segue as diretrizes de estilo deste projeto
- [X] Realizei uma auto-revisão do meu código
- [  ] Comentei meu código, principalmente em áreas difíceis de entender
- [  ] Fiz alterações correspondentes na documentação
- [  ] Minhas alterações não geram novos avisos
- [  ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [  ] Testes de unidade novos e existentes passam localmente com minhas alterações
- [  ] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream
