### PR TITLE
feat: new response - event name conflict on submission

### DIFF
--- a/api/controllers/event.py
+++ b/api/controllers/event.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status, FastAPI, HTTPException
 from api.adapters.aws.file_handler import FileHandlerS3Adapter
 from api.adapters.repository.event import EventAdapter
 from api.adapters.repository.paper import PaperAdapter
@@ -9,7 +9,10 @@ from api.services.event import EventService, EventsPaginatedResponse
 from api.services.file_handler import FileHandlerService
 from api.services.merged_papers import MergedPapersService
 from api.services.summary import SummaryService
+from sqlalchemy.exc import IntegrityError
+from psycopg2.errors import UniqueViolation
 
+app = FastAPI()
 router = APIRouter()
 
 event_adapter = EventAdapter()
@@ -26,12 +29,30 @@ merged_papers_service = MergedPapersService(
 
 anal_service = AnalService(file_handler_service, event_adapter)
 
+@app.exception_handler(IntegrityError)
+async def integrity_error_handler(request, exc):
+    if isinstance(exc.orig, UniqueViolation):
+        error_message = "Um evento já cadastrado possui o mesmo nome"
+        return JSONResponse(status_code=409, content={"error": error_message})
+    else:
+        raise HTTPException(status_code=500, detail="Internal Server Errror")
 
-@router.post("", response_model=EventResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", responses={409: {"description": "Conflito de valores", "model": integrity_error_handler}},
+response_model=EventResponse)
 def create_event(
     event_data: EventDTO, event_service: EventService = Depends(lambda: service)
 ):
-    return event_service.create_event(event_data)
+    try:
+        events = event_service.get_events()
+        return event_service.create_event(event_data)
+    except IntegrityError as e:
+        if isinstance(e.orig, UniqueViolation):
+            error_message = event_data.name + " já é um nome cadastrado."
+            # Return a 409 HTTP response with a JSON payload containing the error message
+            raise HTTPException(status_code=409, detail=error_message)
+        else:
+            # If it's not a unique violation, raise a generic HTTP exception
+            raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("", response_model=EventsPaginatedResponse, status_code=status.HTTP_200_OK)


### PR DESCRIPTION
# Descrição
Inclua um resumo das alterações e do problema relacionado. Inclua também motivação e contexto relevantes.<br>
Liste todas as dependências necessárias para essa alteração.

Ao tentar criar um evento com um nome já cadastrado no sistema, nenhum retorno de erro verboso era apresentado, apenas uma resposta 500 era dada (erro genérico de servidor). Com as alterações, uma resposta de conflito (409) é apresentada, detalhando o erro quanto ao nome de evento.

### Para correções, descreva o problema apresentado (problema):

A _request_ POST de criação de eventos não possui tratamento para conflito de nomes (um campo tipo _unique_), portanto forçava ao db uma criação de evento com nome já cadastrado, o que gerava um erro do tipo _UniqueViolation_. Sem tratamento deste erro, uma resposta 500 era retornada.

## Tipo de mudança
Selecione abaixo o item coerente com o tipo de implementação realizado.

- [  ] Correção de bug [bugfix] (alteração ininterrupta que corrige um problema)
- [X] Novo recurso [feature] (alteração ininterrupta que adiciona funcionalidade)
- [  ] Alteração significativa [hotfix] (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [  ] Esta alteração requer uma atualização da documentação [docs]
- [  ] Recursos de testes [test] (Implementação de recursos para validação/testes no código)
- [  ] Outro recurso não listado nas opções acima [other]

# Como isso foi testado?

Descreva os testes que você executou para verificar suas alterações. Forneça instruções para que possamos reproduzir.
> [!IMPORTANT]
> Liste também quaisquer detalhes relevantes para sua configuração de teste.

- [  ] Teste A

1. Criar um evento no sistema e receber uma resposta positiva de criação;
2. Tentar criar um novo evento, com o exato mesmo nome do anterior (podendo alterar as datas de início e fim);
3. Receber uma resposta de erro por conflito (409) com corpo:
{
  "detail": "<event.name> já é um nome cadastrado."
}

**Configuração de teste**:
* Versão do framework/SDK:
* Browser/Ferramenta utilizada:
Google Chrome; Visual Studio Code IDE
* Caminho a ser testado:

- Usando a página do Swagger, em: localhost:8000/docs;
- - Na seção de eventos;
- - - No end-point Create Events;

# Lista de controle:

- [  ] Meu código segue as diretrizes de estilo deste projeto
- [X] Realizei uma auto-revisão do meu código
- [  ] Comentei meu código, principalmente em áreas difíceis de entender
- [  ] Fiz alterações correspondentes na documentação
- [  ] Minhas alterações não geram novos avisos
- [  ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [X] Testes de unidade novos e existentes passam localmente com minhas alterações
- [  ] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream
