### PR TITLE
Fix da ordenação de eventos

### DIFF
--- a/core/infrastructure/repositories/orm/event.py
+++ b/core/infrastructure/repositories/orm/event.py
@@ -64,15 +64,11 @@ class EventAdapter(EventRepository):
                 sort_column = getattr(Event, sort_by, None)
                 if sort_column:
                     if sort_direction == 'asc':
-                        if sort_by == 'initial_date' or sort_by == 'final_date':
-                            query = query.order_by(func.to_date(sort_column, 'DD-MM-YY').asc())
-                        else:
-                            query = query.order_by(asc(sort_column))
+                        query = query.order_by(asc(sort_column))
                     else:
-                        if sort_by == 'initial_date' or sort_by == 'final_date':
-                            query = query.order_by(func.to_date(sort_column, 'DD-MM-YY').desc())
-                        else:
-                            query = query.order_by(desc(sort_column))
+                        query = query.order_by(desc(sort_column))
+                        
+                            
 
             # Apply pagination
             query = query.limit(page_size).offset((page - 1) * page_size)


### PR DESCRIPTION
# Descrição
Correção da ordenação de eventos, quando passado o sort_by por data.

Erro causado pelo merge, uma das branchs tinha as datas como string e outra atulizou os models das datas, por conta disso a que usava conversão de string para datas apresentou problemas. A correção consiste em apenas remover a conversão de dados na query.

## Tipo de mudança
Selecione abaixo o item coerente com o tipo de implementação realizado.

- [ x ] Correção de bug [bugfix] (alteração ininterrupta que corrige um problema)
- [   ] Novo recurso [feature] (alteração ininterrupta que adiciona funcionalidade)
- [   ] Alteração significativa [hotfix] (correção ou recurso que faria com que a funcionalidade existente não funcionasse conforme o esperado)
- [   ] Esta alteração requer uma atualização da documentação [docs]
- [   ] Recursos de testes [test] (Implementação de recursos para validação/testes no código)
- [   ] Outro recurso não listado nas opções acima [other]

# Como isso foi testado?
- [ x ] Teste no front que consome a rota.
- [ x ] Teste no Swagger nos casos que apresentavam erro.

**Configuração de teste**:
* Versão do framework/SDK: 3,12
* Browser/Ferramenta utilizada: PostgreSQL 16
* Caminho a ser testado: Get /events (com sort_by: final_date ou initial_date)

# Lista de controle:

- [   ] Meu código segue as diretrizes de estilo deste projeto
- [ x ] Realizei uma auto-revisão do meu código
- [   ] Comentei meu código, principalmente em áreas difíceis de entender
- [   ] Fiz alterações correspondentes na documentação
- [   ] Minhas alterações não geram novos avisos
- [   ] Adicionei testes que provam que minha correção é eficaz ou que meu recurso funciona
- [   ] Testes de unidade novos e existentes passam localmente com minhas alterações
- [   ] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream
